### PR TITLE
update to use latest prerelease 4.0 SDK API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ workflows:
       - linux-test:
           name: PHP 7.4
           docker-image: cimg/php:7.4
+      - linux-test:
+          name: PHP 8.0
+          docker-image: cimg/php:8.0
 
 jobs:
   linux-test:

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,10 @@
 {
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/launchdarkly/php-server-sdk-private.git"
+        }
+    ],
     "name": "launchdarkly/server-sdk-shared-tests",
     "description": "Shared unit test code for LaunchDarkly PHP SDK",
     "license": "Apache-2.0",
@@ -12,7 +18,7 @@
         "php": ">=7.3"
     },
     "require-dev": {
-        "launchdarkly/server-sdk": ">=3.9",
+        "launchdarkly/server-sdk": "4.0.x-dev",
         "phpunit/phpunit": "^9"
     },
     "autoload": {

--- a/src/DatabaseFeatureRequesterTestBase.php
+++ b/src/DatabaseFeatureRequesterTestBase.php
@@ -2,15 +2,15 @@
 
 namespace LaunchDarkly\SharedTest;
 
-use LaunchDarkly\FeatureFlag;
 use LaunchDarkly\FeatureRequester;
-use LaunchDarkly\Segment;
+use LaunchDarkly\Impl\Model\FeatureFlag;
+use LaunchDarkly\Impl\Model\Segment;
 use PHPUnit\Framework\TestCase;
 
 /**
  * A base class providing standardized PHPUnit tests for database integrations.
  */
-class DatabaseFeatureRequesterTestBase extends \PHPUnit\Framework\TestCase
+class DatabaseFeatureRequesterTestBase extends TestCase
 {
     const TEST_PREFIX = 'testprefix';
 

--- a/tests/DatabaseFeatureRequesterTestBaseTest.php
+++ b/tests/DatabaseFeatureRequesterTestBaseTest.php
@@ -2,16 +2,16 @@
 
 namespace LaunchDarkly\SharedTest\Tests;
 
-use LaunchDarkly\FeatureFlag;
 use LaunchDarkly\FeatureRequester;
-use LaunchDarkly\Segment;
+use LaunchDarkly\Impl\Model\FeatureFlag;
+use LaunchDarkly\Impl\Model\Segment;
 use LaunchDarkly\SharedTest\DatabaseFeatureRequesterTestBase;
 
 class FakeDatabase
 {
 	public static $data = [];
 
-	public static function getItem($prefix, $namespace, $key)
+	public static function getItem(string $prefix, string $namespace, string $key): ?array
 	{
 		$dataSet = self::$data[$prefix] ?? null;
 		if ($dataSet) {
@@ -24,7 +24,7 @@ class FakeDatabase
 		return null;
 	}
 
-	public static function getAllItems($prefix, $namespace)
+	public static function getAllItems(string $prefix, string $namespace): array
 	{
 		$itemsOut = [];
 		$dataSet = self::$data[$prefix] ?? [];
@@ -35,7 +35,7 @@ class FakeDatabase
 		return $itemsOut;
 	}
 
-	public static function putSerializedItem($prefix, $namespace, $key, $json)
+	public static function putSerializedItem(string $prefix, string $namespace, string $key, string $json): void
 	{
 		if (!isset(self::$data[$prefix])) {
     		self::$data[$prefix] = [];
@@ -56,7 +56,7 @@ class FakeDatabaseFeatureRequester implements \LaunchDarkly\FeatureRequester
 		$this->prefix = $prefix;
 	}
 
-	public function getFeature($key)
+	public function getFeature(string $key): ?FeatureFlag
 	{
 		$json = FakeDatabase::getItem($this->prefix, 'features', $key);
 		if ($json) {
@@ -66,7 +66,7 @@ class FakeDatabaseFeatureRequester implements \LaunchDarkly\FeatureRequester
 		return null;
 	}
 
-    public function getSegment($key)
+    public function getSegment(string $key): ?Segment
     {
     	$json = FakeDatabase::getItem($this->prefix, 'segments', $key);
 		if ($json) {
@@ -76,7 +76,7 @@ class FakeDatabaseFeatureRequester implements \LaunchDarkly\FeatureRequester
 		return null;
     }
 
-    public function getAllFeatures()
+    public function getAllFeatures(): array
     {
     	$jsonList = FakeDatabase::getAllItems($this->prefix, 'features');
     	$itemsOut = [];


### PR DESCRIPTION
This adjusts for the changes made in https://github.com/launchdarkly/php-server-sdk-private/pull/66. It also switches to using the prerelease 4.0.x version of the SDK; previously we were cheating by using 3.9, but that won't work now that these internal classes have moved.

The CI for this project won't pass until we have released the 4.0 SDK and changed composer.json to remove the reference to the private SDK repo, because this project has the standard CircleCI deploy key that's for its own repo only. However, it _will_ pass when we pull this shared code into the Git subtree in the various database integration packages (which I've already done, in PR branches in those repos)... because those have already been set up with deploy keys to access the prerelease SDK. This will be a non-issue after the release.

If you want to verify that the tests here do pass, just clone the code locally and run `composer install && vendor/bin/phpunit`.