### PR TITLE
Updating to be SDK 5.x version compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,11 @@ workflows:
   workflow:
     jobs:
       - linux-test:
-          name: PHP 7.3
-          docker-image: cimg/php:7.3
-      - linux-test:
-          name: PHP 7.4
-          docker-image: cimg/php:7.4
-      - linux-test:
           name: PHP 8.0
           docker-image: cimg/php:8.0
+      - linux-test:
+          name: PHP 8.1
+          docker-image: cimg/php:8.1
 
 jobs:
   linux-test:

--- a/README.md
+++ b/README.md
@@ -4,18 +4,15 @@
 
 This project provides support code for testing LaunchDarkly PHP SDK integrations. Feature store implementations, etc., should use this code whenever possible to ensure consistent test coverage and avoid repetition. An example of a project using this code is [php-server-sdk-redis](https://github.com/launchdarkly/php-server-sdk-redis).
 
-The code is not published to Packagist, since it isn't of any use in any non-test context. Instead, it's meant to be used as a Git subtree. Add the subtree to your project like this:
+The code is not published to Packagist, since it isn't of any use in any non-test context. Instead, it's meant to be used as a git repository source.
 
-    git remote add php-server-sdk-shared-tests git@github.com:launchdarkly/php-server-sdk-shared-tests.git
-    git subtree add --squash --prefix=php-server-sdk-shared-tests/ php-server-sdk-shared-tests main
-
-Then, in your project that uses the shared tests, add this to `composer.json`:
+In your project that uses the shared tests, add this to `composer.json`:
 
 ```json
     "repositories": [
         {
-            "type": "path",
-            "url": "php-server-sdk-shared-tests"
+            "type": "vcs",
+            "url": "https://github.com/launchdarkly/php-server-sdk-shared-tests"
         },
     ],
 ```
@@ -23,9 +20,5 @@ Then, in your project that uses the shared tests, add this to `composer.json`:
 And add this dependency:
 
 ```json
-    "launchdarkly/server-sdk-shared-tests": "@dev"
+    "launchdarkly/server-sdk-shared-tests": "dev-main"
 ```
-
-To update the copy of `php-server-sdk-shared-tests` in your repository to reflect changes in this one:
-
-    git subtree pull --squash --prefix=php-server-sdk-shared-tests/ php-server-sdk-shared-tests main

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3"
+        "php": ">=8.0"
     },
     "require-dev": {
         "launchdarkly/server-sdk": "5.*",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=7.3"
     },
     "require-dev": {
-        "launchdarkly/server-sdk": "4.*",
+        "launchdarkly/server-sdk": "5.*",
         "phpunit/phpunit": "^9"
     },
     "autoload": {

--- a/src/DatabaseFeatureRequesterTestBase.php
+++ b/src/DatabaseFeatureRequesterTestBase.php
@@ -1,10 +1,11 @@
 <?php
 
+
 namespace LaunchDarkly\SharedTest;
 
-use LaunchDarkly\FeatureRequester;
 use LaunchDarkly\Impl\Model\FeatureFlag;
 use LaunchDarkly\Impl\Model\Segment;
+use LaunchDarkly\Subsystems\FeatureRequester;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,7 +18,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * Override this method to remove all data from the underlying data store for
      * the specified prefix string.
-     * 
+     *
      * @param string $prefix the key prefix; may be empty/null, in which case we should
      *   use whatever the default prefix is for this database integration.
      */
@@ -29,11 +30,11 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * Override this method to create an instance of the feature requester class being
      * tested.
-     * 
+     *
      * @param string $prefix the key prefix; may be empty/null, in which case we should
      *   use whatever the default prefix is for this database integration.
-     * 
-     * @return an implementation instance
+     *
+     * @return FeatureRequester an implementation instance
      */
     protected function makeRequester(?string $prefix): FeatureRequester
     {
@@ -63,7 +64,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetFeature(?string $prefix)
+    public function testGetFeature(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -83,7 +84,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetMissingFeature(?string $prefix)
+    public function testGetMissingFeature(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -95,7 +96,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetDeletedFeature(?string $prefix)
+    public function testGetDeletedFeature(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -113,7 +114,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetAllFeatures(?string $prefix)
+    public function testGetAllFeatures(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -131,7 +132,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         $this->putSerializedItem($prefix, 'features', $flagKey3, $flagVersion, $flagJson3);
 
         $flags = $fr->getAllFeatures();
-        
+
         $this->assertEquals(2, count($flags));
         $flag1 = $flags[$flagKey1];
         $this->assertEquals($flagKey1, $flag1->getKey());
@@ -144,7 +145,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testAllFeaturesWithEmptyStore(?string $prefix)
+    public function testAllFeaturesWithEmptyStore(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -156,7 +157,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetSegment(?string $prefix)
+    public function testGetSegment(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -175,7 +176,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetMissingSegment(?string $prefix)
+    public function testGetMissingSegment(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -187,7 +188,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
     /**
      * @dataProvider prefixParameters
      */
-    public function testGetDeletedSegment(?string $prefix)
+    public function testGetDeletedSegment(?string $prefix): void
     {
         $this->clearExistingData($prefix);
         $fr = $this->makeRequester($prefix);
@@ -202,7 +203,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         $this->assertNull($segment);
     }
 
-    public function testPrefixIndependence()
+    public function testPrefixIndependence(): void
     {
         $prefix1 = 'prefix1';
         $prefix2 = 'prefix2';
@@ -226,7 +227,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         $this->verifyForPrefix($this->makeRequester($prefix2), $flagKey, $segmentKey, $version2);
     }
 
-    private function setupForPrefix(?string $prefix, string $flagKey, string $segmentKey, int $flagVersion)
+    private function setupForPrefix(?string $prefix, string $flagKey, string $segmentKey, int $flagVersion): void
     {
         $segmentVersion = $flagVersion * 2;
         $this->putSerializedItem($prefix, 'features', $flagKey, $flagVersion,
@@ -235,7 +236,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
             self::makeSegmentJson($flagKey, $segmentVersion));
     }
 
-    private function verifyForPrefix(FeatureRequester $fr, string $flagKey, string $segmentKey, int $flagVersion)
+    private function verifyForPrefix(FeatureRequester $fr, string $flagKey, string $segmentKey, int $flagVersion): void
     {
         $segmentVersion = $flagVersion * 2;
 
@@ -252,7 +253,10 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         $this->assertEquals($segmentVersion, $segment->getVersion());
     }
 
-    public function prefixParameters()
+    /**
+     * @return array<int,mixed>
+     */
+    public function prefixParameters(): array
     {
         return [
             [ self::TEST_PREFIX ],
@@ -261,7 +265,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         ];
     }
 
-    private static function makeFlagJson(string $key, int $version, bool $deleted = false)
+    private static function makeFlagJson(string $key, int $version, bool $deleted = false): string|bool
     {
         return json_encode(array(
             'key' => $key,
@@ -283,7 +287,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         ));
     }
 
-    private static function makeSegmentJson(string $key, int $version, bool $deleted = false)
+    private static function makeSegmentJson(string $key, int $version, bool $deleted = false): string|bool
     {
         return json_encode(array(
             'key' => $key,
@@ -296,5 +300,3 @@ class DatabaseFeatureRequesterTestBase extends TestCase
         ));
     }
 }
-
-?>

--- a/src/DatabaseFeatureRequesterTestBase.php
+++ b/src/DatabaseFeatureRequesterTestBase.php
@@ -5,7 +5,6 @@ namespace LaunchDarkly\SharedTest;
 
 use LaunchDarkly\Impl\Model\FeatureFlag;
 use LaunchDarkly\Impl\Model\Segment;
-use LaunchDarkly\Subsystems\FeatureRequester;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,9 +33,9 @@ class DatabaseFeatureRequesterTestBase extends TestCase
      * @param string $prefix the key prefix; may be empty/null, in which case we should
      *   use whatever the default prefix is for this database integration.
      *
-     * @return FeatureRequester an implementation instance
+     * @return an implementation instance
      */
-    protected function makeRequester(?string $prefix): FeatureRequester
+    protected function makeRequester(?string $prefix)
     {
         throw new \RuntimeException("test class did not implement makeRequester");
     }
@@ -236,7 +235,7 @@ class DatabaseFeatureRequesterTestBase extends TestCase
             self::makeSegmentJson($flagKey, $segmentVersion));
     }
 
-    private function verifyForPrefix(FeatureRequester $fr, string $flagKey, string $segmentKey, int $flagVersion): void
+    private function verifyForPrefix($fr, string $flagKey, string $segmentKey, int $flagVersion): void
     {
         $segmentVersion = $flagVersion * 2;
 

--- a/tests/DatabaseFeatureRequesterTestBaseTest.php
+++ b/tests/DatabaseFeatureRequesterTestBaseTest.php
@@ -2,122 +2,35 @@
 
 namespace LaunchDarkly\SharedTest\Tests;
 
-use LaunchDarkly\FeatureRequester;
-use LaunchDarkly\Impl\Model\FeatureFlag;
-use LaunchDarkly\Impl\Model\Segment;
 use LaunchDarkly\SharedTest\DatabaseFeatureRequesterTestBase;
-
-class FakeDatabase
-{
-	public static $data = [];
-
-	public static function getItem(string $prefix, string $namespace, string $key): ?array
-	{
-		$dataSet = self::$data[$prefix] ?? null;
-		if ($dataSet) {
-			$items = $dataSet[$namespace] ?? null;
-			if ($items) {
-				$json = $items[$key] ?? null;
-				return $json ? json_decode($json, true) : null;
-			}
-		}
-		return null;
-	}
-
-	public static function getAllItems(string $prefix, string $namespace): array
-	{
-		$itemsOut = [];
-		$dataSet = self::$data[$prefix] ?? [];
-		$items = $dataSet[$namespace] ?? [];
-		foreach ($items as $key => $json) {
-			$itemsOut[$key] = json_decode($json, true);
-		}
-		return $itemsOut;
-	}
-
-	public static function putSerializedItem(string $prefix, string $namespace, string $key, string $json): void
-	{
-		if (!isset(self::$data[$prefix])) {
-    		self::$data[$prefix] = [];
-    	}
-    	if (!isset(self::$data[$prefix][$namespace])) {
-    		self::$data[$prefix][$namespace] = [];
-    	}
-    	self::$data[$prefix][$namespace][$key] = $json;
-	}
-}
-
-class FakeDatabaseFeatureRequester implements \LaunchDarkly\FeatureRequester
-{
-	private $prefix;
-
-	public function __construct($prefix)
-	{
-		$this->prefix = $prefix;
-	}
-
-	public function getFeature(string $key): ?FeatureFlag
-	{
-		$json = FakeDatabase::getItem($this->prefix, 'features', $key);
-		if ($json) {
-			$flag = FeatureFlag::decode($json);
-			return $flag->isDeleted() ? null : $flag;
-		}
-		return null;
-	}
-
-    public function getSegment(string $key): ?Segment
-    {
-    	$json = FakeDatabase::getItem($this->prefix, 'segments', $key);
-		if ($json) {
-			$segment = Segment::decode($json);
-			return $segment->isDeleted() ? null : $segment;
-		}
-		return null;
-    }
-
-    public function getAllFeatures(): array
-    {
-    	$jsonList = FakeDatabase::getAllItems($this->prefix, 'features');
-    	$itemsOut = [];
-        foreach ($jsonList as $json) {
-            $flag = FeatureFlag::decode($json);
-            if ($flag && !$flag->isDeleted()) {
-                $itemsOut[$flag->getKey()] = $flag;
-            }
-        }
-        return $itemsOut;
-    }
-}
+use LaunchDarkly\Subsystems\FeatureRequester;
 
 class DatabaseFeatureRequesterTestBaseTest extends DatabaseFeatureRequesterTestBase
 {
-	const DEFAULT_PREFIX = 'defaultprefix';
+    const DEFAULT_PREFIX = 'defaultprefix';
 
-	protected function clearExistingData(?string $prefix): void
+    protected function clearExistingData(?string $prefix): void
     {
-    	FakeDatabase::$data[$this->actualPrefix($prefix)] = [ 'features' => [], 'segments' => [] ];
+        FakeDatabase::$data[$this->actualPrefix($prefix)] = [ 'features' => [], 'segments' => [] ];
     }
 
-	protected function makeRequester(?string $prefix): FeatureRequester
+    protected function makeRequester(?string $prefix): FeatureRequester
     {
-    	return new FakeDatabaseFeatureRequester($this->actualPrefix($prefix));
+        return new FakeDatabaseFeatureRequester($this->actualPrefix($prefix));
     }
 
     protected function putSerializedItem(
-    	?string $prefix,
-    	string $namespace,
-    	string $key,
-    	int $version,
-    	string $json): void
+        ?string $prefix,
+        string $namespace,
+        string $key,
+        int $version,
+        string $json): void
     {
-    	FakeDatabase::putSerializedItem($this->actualPrefix($prefix), $namespace, $key, $json);
+        FakeDatabase::putSerializedItem($this->actualPrefix($prefix), $namespace, $key, $json);
     }
 
     private function actualPrefix(?string $prefix): string
     {
-    	return ($prefix === null || $prefix === '') ? self::DEFAULT_PREFIX : $prefix;
+        return ($prefix === null || $prefix === '') ? self::DEFAULT_PREFIX : $prefix;
     }
 }
-
-?>

--- a/tests/FakeDatabase.php
+++ b/tests/FakeDatabase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LaunchDarkly\SharedTest\Tests;
+
+class FakeDatabase
+{
+    public static $data = [];
+
+    public static function getItem(string $prefix, string $namespace, string $key): ?array
+    {
+        $dataSet = self::$data[$prefix] ?? null;
+        if ($dataSet) {
+            $items = $dataSet[$namespace] ?? null;
+            if ($items) {
+                $json = $items[$key] ?? null;
+                return $json ? json_decode($json, true) : null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return array<<string>,mixed>
+     */
+    public static function getAllItems(string $prefix, string $namespace): array
+    {
+        $itemsOut = [];
+        $dataSet = self::$data[$prefix] ?? [];
+        $items = $dataSet[$namespace] ?? [];
+        foreach ($items as $key => $json) {
+            $itemsOut[$key] = json_decode($json, true);
+        }
+        return $itemsOut;
+    }
+
+    public static function putSerializedItem(string $prefix, string $namespace, string $key, string $json): void
+    {
+        if (!isset(self::$data[$prefix])) {
+            self::$data[$prefix] = [];
+        }
+        if (!isset(self::$data[$prefix][$namespace])) {
+            self::$data[$prefix][$namespace] = [];
+        }
+        self::$data[$prefix][$namespace][$key] = $json;
+    }
+}

--- a/tests/FakeDatabaseFeatureRequester.php
+++ b/tests/FakeDatabaseFeatureRequester.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace LaunchDarkly\SharedTest\Tests;
+
+use LaunchDarkly\Impl\Model\FeatureFlag;
+use LaunchDarkly\Impl\Model\Segment;
+use LaunchDarkly\Subsystems\FeatureRequester;
+
+class FakeDatabaseFeatureRequester implements FeatureRequester
+{
+    private $prefix;
+
+    public function __construct($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    public function getFeature(string $key): ?FeatureFlag
+    {
+        $json = FakeDatabase::getItem($this->prefix, 'features', $key);
+        if ($json) {
+            $flag = FeatureFlag::decode($json);
+            return $flag->isDeleted() ? null : $flag;
+        }
+        return null;
+    }
+
+    public function getSegment(string $key): ?Segment
+    {
+        $json = FakeDatabase::getItem($this->prefix, 'segments', $key);
+        if ($json) {
+            $segment = Segment::decode($json);
+            return $segment->isDeleted() ? null : $segment;
+        }
+        return null;
+    }
+
+    public function getAllFeatures(): array
+    {
+        $jsonList = FakeDatabase::getAllItems($this->prefix, 'features');
+        $itemsOut = [];
+        foreach ($jsonList as $json) {
+            $flag = FeatureFlag::decode($json);
+            if ($flag && !$flag->isDeleted()) {
+                $itemsOut[$flag->getKey()] = $flag;
+            }
+        }
+        return $itemsOut;
+    }
+}


### PR DESCRIPTION
Our shared test structure references namespaces that no longer exist in
the 5.x release of the SDK.
    
In addition to the above change, this commit also introduces the
following set of changes:
    
- Bump minimum PHP to 8.0 in accordance with the PHP SDK requirements.
- Updates README with new recommendations for expected usage of this
  repository.
- Makes some stylistic improvements (spaces over tabs, no ending closing
  tag)
- Makes some LSP sourced recommendations (one class per file, docblocks,
  return types)